### PR TITLE
Add picker/unpickler for java.util.Date

### DIFF
--- a/shared/main/scala/prickle/Pickler.scala
+++ b/shared/main/scala/prickle/Pickler.scala
@@ -5,6 +5,7 @@ import scala.language.experimental.macros
 import scala.collection.mutable
 import microjson._
 
+import java.util.Date
 
 /** Use this object to invoke Pickling from user code */
 object Pickle {
@@ -104,6 +105,11 @@ object Pickler extends MaterializePicklerFallback {
   implicit object StringPickler extends Pickler[String] {
     def pickle[P](x: String, state: PickleState)(implicit config: PConfig[P]): P =
       config.makeString(x)
+  }
+
+  implicit object DatePickler extends Pickler[Date] {
+    def pickle[P](x: Date, state: PickleState)(implicit config: PConfig[P]): P =
+      config.makeNumber(x.getTime)
   }
 
   implicit def mapPickler[K, V](implicit kpickler: Pickler[K], vpickler: Pickler[V]) = new Pickler[Map[K, V]] {

--- a/shared/main/scala/prickle/Unpickler.scala
+++ b/shared/main/scala/prickle/Unpickler.scala
@@ -6,6 +6,8 @@ import collection.mutable
 import scala.language.experimental.macros
 import microjson._
 
+import java.util.Date
+
 /** Use this object to invoke Unpickling from user code */
 object Unpickle {
 
@@ -91,6 +93,11 @@ object Unpickler extends MaterializeUnpicklerFallback {
       else
         config.readString(pickle)
     }
+  }
+
+  implicit object DateUnpickler extends Unpickler[Date] {
+    def unpickle[P](pickle: P, state: mutable.Map[String, Any])(implicit config: PConfig[P]) =
+      config.readNumber(pickle).map(_.toLong).map(new Date(_))
   }
 
   implicit def mapUnpickler[K, V](implicit ku: Unpickler[K], vu: Unpickler[V]) =  new Unpickler[Map[K, V]] {


### PR DESCRIPTION
As `java.util.Date` has been implemented in _Scala.js_ since 0.5.1(https://github.com/scala-js/scala-js/issues/759), we need to support pickling/unpickling for the data type.
