### PR TITLE
Removed buggy (and unnecessary?) removal of trailing zeroes and dot from...

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object Build extends sbt.Build{
   val cross = new utest.jsrunner.JsCrossBuild(
     organization := "com.github.benhutchison",
 
-    version := "1.1.0",
+    version := "1.1.1-ahnfelt",
     scalaVersion := "2.11.2",
     name := "prickle",
     crossScalaVersions := Seq("2.10.4", "2.11.2"),

--- a/shared/main/scala/prickle/PConfig.scala
+++ b/shared/main/scala/prickle/PConfig.scala
@@ -68,12 +68,7 @@ trait JsBuilder extends PBuilder[JsValue] {
   def makeNull(): JsValue = JsNull
   def makeBoolean(b: Boolean): JsValue = if (b) JsTrue else JsFalse
   def makeNumber(x: Double): JsValue = {
-    val raw = x.toString
-    val s = if (raw.contains("."))
-      new String(raw.toCharArray.reverse.dropWhile(_ == '0').dropWhile(_ == '.').reverse)
-    else
-      raw
-    JsNumber(s)
+    JsNumber(x.toString) // TODO: Handle NaN and +-Infinity, both of which are not supported by JSON
   }
 
   def makeString(s: String): JsValue = JsString(s)


### PR DESCRIPTION
... Double.

Also added a TODO, as per RFC 4627, section 2.4:

   "Numeric values that cannot be represented as sequences of digits
   (such as Infinity and NaN) are not permitted."