### PR TITLE
Remove utest dependency from published package.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -55,11 +55,11 @@ object Build extends sbt.Build{
     settings(sharedSettings: _*).
     jsSettings(
       libraryDependencies += "com.github.benhutchison" %%% "microjson" % "1.3",
-      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1"
+      libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1" % "test"
     ).
     jvmSettings(
       libraryDependencies += "com.github.benhutchison" %% "microjson" % "1.3",
-      libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.1"
+      libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.1" % "test"
     )
 
   lazy val js = cross.js


### PR DESCRIPTION
I only did very based testing (sbt test and building another project using a locally published version), but builds still work fine and that's what would probably fail from this change.

BTW, I found prickle very useful in a case where I needed to pickle scala objects to native JS objects. I could override the JSON backend to just use native values and it works great.